### PR TITLE
feat: [PoC] Add instrumentation hook to SvelteKit

### DIFF
--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
@@ -79,6 +79,8 @@ export default function (opts = {}) {
 				chunkFileNames: 'chunks/[name]-[hash].js'
 			});
 
+			const hooksFile = readdirSync(`${out}/server/chunks`).find((file) => file.startsWith('hooks.server-') && file.endsWith('.js'));
+
 			builder.copy(files, out, {
 				replace: {
 					ENV: './env.js',
@@ -86,7 +88,8 @@ export default function (opts = {}) {
 					MANIFEST: './server/manifest.js',
 					SERVER: './server/index.js',
 					SHIMS: './shims.js',
-					ENV_PREFIX: JSON.stringify(envPrefix)
+					ENV_PREFIX: JSON.stringify(envPrefix),
+					SERVER_HOOKS: hooksFile ? `./server/chunks/${hooksFile}` : 'null',
 				}
 			});
 		},

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -21,6 +21,15 @@ export default [
 			format: 'esm'
 		},
 		plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json(), prefixBuiltinModules()],
+		external: ['SERVER_HOOKS', './start.js']
+	},
+	{
+		input: 'src/start.js',
+		output: {
+			file: 'files/start.js',
+			format: 'esm'
+		},
+		plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json(), prefixBuiltinModules()],
 		external: ['ENV', 'HANDLER']
 	},
 	{

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,105 +1,14 @@
-import process from 'node:process';
-import { handler } from 'HANDLER';
-import { env } from 'ENV';
-import polka from 'polka';
+import { existsSync } from 'node:fs';
 
-export const path = env('SOCKET_PATH', false);
-export const host = env('HOST', '0.0.0.0');
-export const port = env('PORT', !path && '3000');
+const dirname = new URL('.', import.meta.url).pathname;
 
-const shutdown_timeout = parseInt(env('SHUTDOWN_TIMEOUT', '30'));
-const idle_timeout = parseInt(env('IDLE_TIMEOUT', '0'));
-const listen_pid = parseInt(env('LISTEN_PID', '0'));
-const listen_fds = parseInt(env('LISTEN_FDS', '0'));
-// https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html
-const SD_LISTEN_FDS_START = 3;
-
-if (listen_pid !== 0 && listen_pid !== process.pid) {
-	throw new Error(`received LISTEN_PID ${listen_pid} but current process id is ${process.pid}`);
-}
-if (listen_fds > 1) {
-	throw new Error(
-		`only one socket is allowed for socket activation, but LISTEN_FDS was set to ${listen_fds}`
-	);
-}
-
-const socket_activation = listen_pid === process.pid && listen_fds === 1;
-
-let requests = 0;
-/** @type {NodeJS.Timeout | void} */
-let shutdown_timeout_id;
-/** @type {NodeJS.Timeout | void} */
-let idle_timeout_id;
-
-const server = polka().use(handler);
-
-if (socket_activation) {
-	server.listen({ fd: SD_LISTEN_FDS_START }, () => {
-		console.log(`Listening on file descriptor ${SD_LISTEN_FDS_START}`);
-	});
+if (existsSync(`${dirname}/SERVER_HOOKS`)) {
+    import('SERVER_HOOKS').then((hooks) => {
+        if (hooks?.instrument && typeof hooks.instrument === 'function') {
+            hooks.instrument();
+        }
+        import('./start.js')
+    });
 } else {
-	server.listen({ path, host, port }, () => {
-		console.log(`Listening on ${path || `http://${host}:${port}`}`);
-	});
+    import('./start.js');
 }
-
-/** @param {'SIGINT' | 'SIGTERM' | 'IDLE'} reason */
-function graceful_shutdown(reason) {
-	if (shutdown_timeout_id) return;
-
-	// If a connection was opened with a keep-alive header close() will wait for the connection to
-	// time out rather than close it even if it is not handling any requests, so call this first
-	// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
-	server.server.closeIdleConnections();
-
-	server.server.close((error) => {
-		// occurs if the server is already closed
-		if (error) return;
-
-		if (shutdown_timeout_id) {
-			clearTimeout(shutdown_timeout_id);
-		}
-		if (idle_timeout_id) {
-			clearTimeout(idle_timeout_id);
-		}
-
-		// @ts-expect-error custom events cannot be typed
-		process.emit('sveltekit:shutdown', reason);
-	});
-
-	shutdown_timeout_id = setTimeout(
-		// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
-		() => server.server.closeAllConnections(),
-		shutdown_timeout * 1000
-	);
-}
-
-server.server.on(
-	'request',
-	/** @param {import('node:http').IncomingMessage} req */
-	(req) => {
-		requests++;
-
-		if (socket_activation && idle_timeout_id) {
-			idle_timeout_id = clearTimeout(idle_timeout_id);
-		}
-
-		req.on('close', () => {
-			requests--;
-
-			if (shutdown_timeout_id) {
-				// close connections as soon as they become idle, so they don't accept new requests
-				// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
-				server.server.closeIdleConnections();
-			}
-			if (requests === 0 && socket_activation && idle_timeout) {
-				idle_timeout_id = setTimeout(() => graceful_shutdown('IDLE'), idle_timeout * 1000);
-			}
-		});
-	}
-);
-
-process.on('SIGTERM', graceful_shutdown);
-process.on('SIGINT', graceful_shutdown);
-
-export { server };

--- a/packages/adapter-node/src/start.js
+++ b/packages/adapter-node/src/start.js
@@ -1,0 +1,105 @@
+import process from 'node:process';
+import { handler } from 'HANDLER';
+import { env } from 'ENV';
+import polka from 'polka';
+
+export const path = env('SOCKET_PATH', false);
+export const host = env('HOST', '0.0.0.0');
+export const port = env('PORT', !path && '3000');
+
+const shutdown_timeout = parseInt(env('SHUTDOWN_TIMEOUT', '30'));
+const idle_timeout = parseInt(env('IDLE_TIMEOUT', '0'));
+const listen_pid = parseInt(env('LISTEN_PID', '0'));
+const listen_fds = parseInt(env('LISTEN_FDS', '0'));
+// https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html
+const SD_LISTEN_FDS_START = 3;
+
+if (listen_pid !== 0 && listen_pid !== process.pid) {
+	throw new Error(`received LISTEN_PID ${listen_pid} but current process id is ${process.pid}`);
+}
+if (listen_fds > 1) {
+	throw new Error(
+		`only one socket is allowed for socket activation, but LISTEN_FDS was set to ${listen_fds}`
+	);
+}
+
+const socket_activation = listen_pid === process.pid && listen_fds === 1;
+
+let requests = 0;
+/** @type {NodeJS.Timeout | void} */
+let shutdown_timeout_id;
+/** @type {NodeJS.Timeout | void} */
+let idle_timeout_id;
+
+const server = polka().use(handler);
+
+if (socket_activation) {
+	server.listen({ fd: SD_LISTEN_FDS_START }, () => {
+		console.log(`Listening on file descriptor ${SD_LISTEN_FDS_START}`);
+	});
+} else {
+	server.listen({ path, host, port }, () => {
+		console.log(`Listening on ${path || `http://${host}:${port}`}`);
+	});
+}
+
+/** @param {'SIGINT' | 'SIGTERM' | 'IDLE'} reason */
+function graceful_shutdown(reason) {
+	if (shutdown_timeout_id) return;
+
+	// If a connection was opened with a keep-alive header close() will wait for the connection to
+	// time out rather than close it even if it is not handling any requests, so call this first
+	// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
+	server.server.closeIdleConnections();
+
+	server.server.close((error) => {
+		// occurs if the server is already closed
+		if (error) return;
+
+		if (shutdown_timeout_id) {
+			clearTimeout(shutdown_timeout_id);
+		}
+		if (idle_timeout_id) {
+			clearTimeout(idle_timeout_id);
+		}
+
+		// @ts-expect-error custom events cannot be typed
+		process.emit('sveltekit:shutdown', reason);
+	});
+
+	shutdown_timeout_id = setTimeout(
+		// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
+		() => server.server.closeAllConnections(),
+		shutdown_timeout * 1000
+	);
+}
+
+server.server.on(
+	'request',
+	/** @param {import('node:http').IncomingMessage} req */
+	(req) => {
+		requests++;
+
+		if (socket_activation && idle_timeout_id) {
+			idle_timeout_id = clearTimeout(idle_timeout_id);
+		}
+
+		req.on('close', () => {
+			requests--;
+
+			if (shutdown_timeout_id) {
+				// close connections as soon as they become idle, so they don't accept new requests
+				// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
+				server.server.closeIdleConnections();
+			}
+			if (requests === 0 && socket_activation && idle_timeout) {
+				idle_timeout_id = setTimeout(() => graceful_shutdown('IDLE'), idle_timeout * 1000);
+			}
+		});
+	}
+);
+
+process.on('SIGTERM', graceful_shutdown);
+process.on('SIGINT', graceful_shutdown);
+
+export { server };

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,6 +18,7 @@
 	"homepage": "https://svelte.dev",
 	"type": "module",
 	"dependencies": {
+		"@opentelemetry/api": "^1.9.0",
 		"@types/cookie": "^0.6.0",
 		"cookie": "^0.6.0",
 		"devalue": "^5.1.0",

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -854,6 +854,12 @@ export interface Transporter<
 }
 
 /**
+ * Server-side instrumentation function that's evaluated before the server application
+ * is imported to guarantee instrumentation of builtin and user-imported modules.
+ */
+export type Instrument = () => void;
+
+/**
  * The generic form of `PageLoad` and `LayoutLoad`. You should import those from `./$types` (see [generated types](https://svelte.dev/docs/kit/types#Generated-types))
  * rather than using `Load` directly.
  */

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -3,6 +3,7 @@ import { disable_search, make_trackable } from '../../../utils/url.js';
 import { validate_depends } from '../../shared.js';
 import { b64_encode } from '../../utils.js';
 import { with_event } from '../../app/server/event.js';
+import { startAndEndSpan } from '../../../utils/telemetry.js';
 
 /**
  * Calls the user's server `load` function.
@@ -200,17 +201,19 @@ export async function load_data({
 		return server_data_node?.data ?? null;
 	}
 
-	const result = await node.universal.load.call(null, {
-		url: event.url,
-		params: event.params,
-		data: server_data_node?.data ?? null,
-		route: event.route,
-		fetch: create_universal_fetch(event, state, fetched, csr, resolve_opts),
-		setHeaders: event.setHeaders,
-		depends: () => {},
-		parent,
-		untrack: (fn) => fn()
-	});
+	const result = await startAndEndSpan(`universal load ${event.route.id}`, {}, () =>
+		node.universal?.load?.call(null, {
+			url: event.url,
+			params: event.params,
+			data: server_data_node?.data ?? null,
+			route: event.route,
+			fetch: create_universal_fetch(event, state, fetched, csr, resolve_opts),
+			setHeaders: event.setHeaders,
+			depends: () => {},
+			parent,
+			untrack: (fn) => fn()
+		})
+	);
 
 	if (__SVELTEKIT_DEV__) {
 		validate_load_response(result, node.universal_id);

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -34,6 +34,8 @@ import {
 	strip_resolution_suffix
 } from '../pathname.js';
 import { with_event } from '../app/server/event.js';
+import { startAndEndSpan } from '../../../utils/telemetry.js';
+
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
 /* global __SVELTEKIT_DEV__ */
@@ -460,18 +462,20 @@ export async function respond(request, options, manifest, state) {
 			}
 
 			if (options.hash_routing || state.prerendering?.fallback) {
-				return await render_response({
-					event,
-					options,
-					manifest,
-					state,
-					page_config: { ssr: false, csr: true },
-					status: 200,
-					error: null,
-					branch: [],
-					fetched: [],
-					resolve_opts
-				});
+				return await startAndEndSpan('sveltekit - render_response', {}, () =>
+					render_response({
+						event,
+						options,
+						manifest,
+						state,
+						page_config: { ssr: false, csr: true },
+						status: 200,
+						error: null,
+						branch: [],
+						fetched: [],
+						resolve_opts
+					})
+				);
 			}
 
 			if (route) {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -836,6 +836,13 @@ declare module '@sveltejs/kit' {
 	}
 
 	/**
+	 * Server-side instrumentation function that's evaluated before the server application
+	 * is imported to guarantee instrumentation of builtin and user-imported modules.
+	 */
+	export type Instrument = () => void;
+
+
+	/**
 	 * The generic form of `PageLoad` and `LayoutLoad`. You should import those from `./$types` (see [generated types](https://svelte.dev/docs/kit/types#Generated-types))
 	 * rather than using `Load` directly.
 	 */

--- a/playgrounds/basic/svelte.config.js
+++ b/playgrounds/basic/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-node';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
 
   packages/kit:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1689,6 +1692,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4035,6 +4042,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
This is a super early draft of how I'd propose to support server-side instrumentation in SvelteKit. It's not nearly polished and I'm aware of some things that we'd definitely need to improve on in the future. 

So far, this PoC only works with `@sveltejs/adapter-node`!

Here's how usage currently works (**I don't think this should be the final API**)

1. In your `hooks.server.ts` file, add a new `instrument` hook:
```ts
export const instrument = () => {
	// init Otel SDK
        // or Sentry.init(), ddog.start(), etc...
};
```

2. Build app and run `node ./build` as usually

## Benefits

* Invocation of instrument file is done in adapters -> approach can differ per deployment platform. 
* Any kind of instrumentation can live in this file; completely vendor-neutral

## Drawbacks

* Adding support for this per adapter is tedious - can we find a middle ground?

## Improvements

* Instrument code should live in its own file, not in server hooks. This is because you can use virtual file imports in hooks but these won't be available before the app starts. We should make it explicitly clear that instrumentation code is not running on the same level as application code to avoid confusion. In NextJS, this file is simply called `instrumentation.ts`.
* Right now, SvelteKit declares a hard dependency on Otel packages. This was done for simplicity. We should actually only declare peer dependencies and dynamically import the user-installed (or Sentry-included) otel packages, based on availability. If nothing is installed, we should provide a no-op facade so that nothing breaks. This is fairly similar to what NextJS is doing.
* Add more framework-generated spans and more meaningful attributes. Make it clear which spans measure framework-internal vs. user-created duration. (e.g. request handling vs. load function and handle hook evaluations time) 