### PR TITLE
feat: Enable server-side instrumentation via `instrument.server.ts` file

### DIFF
--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -21,6 +21,15 @@ export default [
 			format: 'esm'
 		},
 		plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json(), prefixBuiltinModules()],
+		external: ['./start.js']
+	},
+	{
+		input: 'src/start.js',
+		output: {
+			file: 'files/start.js',
+			format: 'esm'
+		},
+		plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json(), prefixBuiltinModules()],
 		external: ['ENV', 'HANDLER']
 	},
 	{

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,105 +1,17 @@
-import process from 'node:process';
-import { handler } from 'HANDLER';
-import { env } from 'ENV';
-import polka from 'polka';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
-export const path = env('SOCKET_PATH', false);
-export const host = env('HOST', '0.0.0.0');
-export const port = env('PORT', !path && '3000');
+const dirname = new URL('.', import.meta.url).pathname;
 
-const shutdown_timeout = parseInt(env('SHUTDOWN_TIMEOUT', '30'));
-const idle_timeout = parseInt(env('IDLE_TIMEOUT', '0'));
-const listen_pid = parseInt(env('LISTEN_PID', '0'));
-const listen_fds = parseInt(env('LISTEN_FDS', '0'));
-// https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html
-const SD_LISTEN_FDS_START = 3;
+const instrumentFile = join(dirname, 'server', 'instrument.server.js');
 
-if (listen_pid !== 0 && listen_pid !== process.pid) {
-	throw new Error(`received LISTEN_PID ${listen_pid} but current process id is ${process.pid}`);
-}
-if (listen_fds > 1) {
-	throw new Error(
-		`only one socket is allowed for socket activation, but LISTEN_FDS was set to ${listen_fds}`
-	);
-}
-
-const socket_activation = listen_pid === process.pid && listen_fds === 1;
-
-let requests = 0;
-/** @type {NodeJS.Timeout | void} */
-let shutdown_timeout_id;
-/** @type {NodeJS.Timeout | void} */
-let idle_timeout_id;
-
-const server = polka().use(handler);
-
-if (socket_activation) {
-	server.listen({ fd: SD_LISTEN_FDS_START }, () => {
-		console.log(`Listening on file descriptor ${SD_LISTEN_FDS_START}`);
+if (existsSync(instrumentFile)) {
+	import(instrumentFile).then((hooks) => {
+		if (hooks?.instrument && typeof hooks.instrument === 'function') {
+			hooks.instrument();
+		}
+		import('./start.js');
 	});
 } else {
-	server.listen({ path, host, port }, () => {
-		console.log(`Listening on ${path || `http://${host}:${port}`}`);
-	});
+	import('c');
 }
-
-/** @param {'SIGINT' | 'SIGTERM' | 'IDLE'} reason */
-function graceful_shutdown(reason) {
-	if (shutdown_timeout_id) return;
-
-	// If a connection was opened with a keep-alive header close() will wait for the connection to
-	// time out rather than close it even if it is not handling any requests, so call this first
-	// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
-	server.server.closeIdleConnections();
-
-	server.server.close((error) => {
-		// occurs if the server is already closed
-		if (error) return;
-
-		if (shutdown_timeout_id) {
-			clearTimeout(shutdown_timeout_id);
-		}
-		if (idle_timeout_id) {
-			clearTimeout(idle_timeout_id);
-		}
-
-		// @ts-expect-error custom events cannot be typed
-		process.emit('sveltekit:shutdown', reason);
-	});
-
-	shutdown_timeout_id = setTimeout(
-		// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
-		() => server.server.closeAllConnections(),
-		shutdown_timeout * 1000
-	);
-}
-
-server.server.on(
-	'request',
-	/** @param {import('node:http').IncomingMessage} req */
-	(req) => {
-		requests++;
-
-		if (socket_activation && idle_timeout_id) {
-			idle_timeout_id = clearTimeout(idle_timeout_id);
-		}
-
-		req.on('close', () => {
-			requests--;
-
-			if (shutdown_timeout_id) {
-				// close connections as soon as they become idle, so they don't accept new requests
-				// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
-				server.server.closeIdleConnections();
-			}
-			if (requests === 0 && socket_activation && idle_timeout) {
-				idle_timeout_id = setTimeout(() => graceful_shutdown('IDLE'), idle_timeout * 1000);
-			}
-		});
-	}
-);
-
-process.on('SIGTERM', graceful_shutdown);
-process.on('SIGINT', graceful_shutdown);
-
-export { server };

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -6,12 +6,19 @@ const dirname = new URL('.', import.meta.url).pathname;
 const instrumentFile = join(dirname, 'server', 'instrument.server.js');
 
 if (existsSync(instrumentFile)) {
-	import(instrumentFile).then((hooks) => {
-		if (hooks?.instrument && typeof hooks.instrument === 'function') {
-			hooks.instrument();
-		}
-		import('./start.js');
-	});
+	import(instrumentFile)
+		.catch((err) => {
+			console.error('Failed to import instrument.server.js', err);
+		})
+		.finally(() => {
+			tryImportStart();
+		});
 } else {
-	import('c');
+	tryImportStart();
+}
+
+function tryImportStart() {
+	import('./start.js').catch((err) => {
+		console.error('Failed to import server (start.js)', err);
+	});
 }

--- a/packages/adapter-node/src/start.js
+++ b/packages/adapter-node/src/start.js
@@ -1,0 +1,105 @@
+import process from 'node:process';
+import { handler } from 'HANDLER';
+import { env } from 'ENV';
+import polka from 'polka';
+
+export const path = env('SOCKET_PATH', false);
+export const host = env('HOST', '0.0.0.0');
+export const port = env('PORT', !path && '3000');
+
+const shutdown_timeout = parseInt(env('SHUTDOWN_TIMEOUT', '30'));
+const idle_timeout = parseInt(env('IDLE_TIMEOUT', '0'));
+const listen_pid = parseInt(env('LISTEN_PID', '0'));
+const listen_fds = parseInt(env('LISTEN_FDS', '0'));
+// https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html
+const SD_LISTEN_FDS_START = 3;
+
+if (listen_pid !== 0 && listen_pid !== process.pid) {
+	throw new Error(`received LISTEN_PID ${listen_pid} but current process id is ${process.pid}`);
+}
+if (listen_fds > 1) {
+	throw new Error(
+		`only one socket is allowed for socket activation, but LISTEN_FDS was set to ${listen_fds}`
+	);
+}
+
+const socket_activation = listen_pid === process.pid && listen_fds === 1;
+
+let requests = 0;
+/** @type {NodeJS.Timeout | void} */
+let shutdown_timeout_id;
+/** @type {NodeJS.Timeout | void} */
+let idle_timeout_id;
+
+const server = polka().use(handler);
+
+if (socket_activation) {
+	server.listen({ fd: SD_LISTEN_FDS_START }, () => {
+		console.log(`Listening on file descriptor ${SD_LISTEN_FDS_START}`);
+	});
+} else {
+	server.listen({ path, host, port }, () => {
+		console.log(`Listening on ${path || `http://${host}:${port}`}`);
+	});
+}
+
+/** @param {'SIGINT' | 'SIGTERM' | 'IDLE'} reason */
+function graceful_shutdown(reason) {
+	if (shutdown_timeout_id) return;
+
+	// If a connection was opened with a keep-alive header close() will wait for the connection to
+	// time out rather than close it even if it is not handling any requests, so call this first
+	// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
+	server.server.closeIdleConnections();
+
+	server.server.close((error) => {
+		// occurs if the server is already closed
+		if (error) return;
+
+		if (shutdown_timeout_id) {
+			clearTimeout(shutdown_timeout_id);
+		}
+		if (idle_timeout_id) {
+			clearTimeout(idle_timeout_id);
+		}
+
+		// @ts-expect-error custom events cannot be typed
+		process.emit('sveltekit:shutdown', reason);
+	});
+
+	shutdown_timeout_id = setTimeout(
+		// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
+		() => server.server.closeAllConnections(),
+		shutdown_timeout * 1000
+	);
+}
+
+server.server.on(
+	'request',
+	/** @param {import('node:http').IncomingMessage} req */
+	(req) => {
+		requests++;
+
+		if (socket_activation && idle_timeout_id) {
+			idle_timeout_id = clearTimeout(idle_timeout_id);
+		}
+
+		req.on('close', () => {
+			requests--;
+
+			if (shutdown_timeout_id) {
+				// close connections as soon as they become idle, so they don't accept new requests
+				// @ts-expect-error this was added in 18.2.0 but is not reflected in the types
+				server.server.closeIdleConnections();
+			}
+			if (requests === 0 && socket_activation && idle_timeout) {
+				idle_timeout_id = setTimeout(() => graceful_shutdown('IDLE'), idle_timeout * 1000);
+			}
+		});
+	}
+);
+
+process.on('SIGTERM', graceful_shutdown);
+process.on('SIGINT', graceful_shutdown);
+
+export { server };

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -631,6 +631,11 @@ Tips:
 						const name = posixify(path.join('entries/matchers', key));
 						input[name] = path.resolve(file);
 					});
+
+					const instrument_server = resolve_entry('src/instrument.server');
+					if (instrument_server) {
+						input['instrument.server'] = instrument_server;
+					}
 				} else if (svelte_config.kit.output.bundleStrategy !== 'split') {
 					input['bundle'] = `${runtime_directory}/client/bundle.js`;
 				} else {

--- a/playgrounds/basic/svelte.config.js
+++ b/playgrounds/basic/svelte.config.js
@@ -1,9 +1,9 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-node';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		adapter: adapter({})
 	}
 };
 


### PR DESCRIPTION
Supersedes #1 

Adds minimal adaption for SvelteKit to support registering ESM server-side instrumentation in a dedicated `instrument.server.ts` file prior to SvelteKit's server being bootstrapped. 

Concrete changes:
- `@sveltejs/kit`
  - add `instrument.server.(js|ts)` to file output (s.t. it can be transpiled)
- `@sveltejs/adapter-node`
  - add transpiled `instrument.server.js` to secondary server build
  - add dynamic import of `instrument.server.js` (if available) to server entry

## Usage

```ts
// instrument.server.ts

// add arbitrary instrumentation code here, for example:
import { NodeSDK } from "@opentelemetry/sdk-node";
import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
import { createAddHookMessageChannel } from "import-in-the-middle";
import { register } from "module";

const { registerOptions, waitForAllMessagesAcknowledged } =
  createAddHookMessageChannel();
register("import-in-the-middle/hook.mjs", import.meta.url, registerOptions);

const sdk = new NodeSDK({
  serviceName: "demo-todo-app",
  traceExporter: new OTLPTraceExporter(),
  instrumentations: [getNodeAutoInstrumentations()],
});

sdk.start();

await waitForAllMessagesAcknowledged();
```



In contrast to #1, this PR no longer adds kit-internal span instrumentation or Otel handling. I think this can be tackled as a next step or be replaced with a more universal solution (`diagnostic_channels` 👀)